### PR TITLE
docs: warn about problems with TTN Data Storage integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ function Decoder(bytes, port) {
 
 Copy example payload message from the datasheet, paste into `Payload`, and click `Test`. Make sure the output values match against the datasheet example and  save the decoder.
 
+The decoders may output nested objects, which are stored as text in the TTN Data Storage integration.
+
 :warning: The decoders may output a field named `device_id`, which may prohobit per-device querying in the TTN Data Storage integration.
 
 ## ELEMENT IoT

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ function Decoder(bytes, port) {
 
 Copy example payload message from the datasheet, paste into `Payload`, and click `Test`. Make sure the output values match against the datasheet example and  save the decoder.
 
+:warning: The decoders may output a field named `device_id`, which may prohobit per-device querying in the TTN Data Storage integration.
+
 ## ELEMENT IoT
 
 Go to `Automation`, `Parser`, and create a new parser. Take *ELEMENT-IoT Elixir* implementation and paste into the `Code` window by overwriting its content. Test the provided payloads against the datasheet and save.


### PR DESCRIPTION
This PR adds two notes about using the TTN Data Storage integration. Background:

Some or all JavaScript decoders output a field called `device_id`, like:

```javascript
var result = {'protocol_version': version, 'device_id': deviceId};
```

This breaks querying in the TTN Data Storage integration, as the TTN-added field with the same name [will then be stored as `device_id_1`](https://www.thethingsnetwork.org/forum/t/data-storage-device-id-query-not-working/40516/11):

```json
...
"device_id": 5100,
"device_id_1": "user-defined device ID known in TTN Console",
```

This makes getting data for _all_ devices in a specific TTN Application work just fine, but limiting on a specific device ID yields a HTTP 204 with zero results (regardless which of the above two values is used in such query).

Also, the Data Storage integration does not work great with the nested objects in the output:

```json
[
  {
    "battery_voltage": "map[value:2.744 displayName:Battery voltage unit:V]",
    "device_id": 5100,
    "device_id_1": "dl-pr26_5100",
    "pressure": "map[displayName:Pressure unit:bar value:0.030670166015625]",
    "protocol_version": 2,
    "raw": "AhPsAAND7VJFCrg=",
    "temperature": "map[displayName:Temperature unit:°C value:14.615625000000009]",
    "time": "2020-10-15T12:49:46.585897243Z"
  },
]
```

(Above, `dl-pr26_5100` is the user-defined device ID as known in TTN Console.)